### PR TITLE
Add basic AI Q&A web app (HTML, CSS, TypeScript, JS)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,75 @@
+const apiKeyInput = document.querySelector("#apiKey");
+const questionInput = document.querySelector("#question");
+const askBtn = document.querySelector("#askBtn");
+const answerEl = document.querySelector("#answer");
+
+if (!apiKeyInput || !questionInput || !askBtn || !answerEl) {
+  throw new Error("Elementos do app não encontrados no DOM.");
+}
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const FREE_MODEL = "meta-llama/llama-3.3-8b-instruct:free";
+
+async function askAI(apiKey, question) {
+  const messages = [
+    {
+      role: "system",
+      content: "Você é um assistente útil e responde em português do Brasil.",
+    },
+    { role: "user", content: question },
+  ];
+
+  const response = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "HTTP-Referer": window.location.origin,
+      "X-Title": "App IA Grátis Exemplo",
+    },
+    body: JSON.stringify({
+      model: FREE_MODEL,
+      messages,
+      temperature: 0.7,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const errorMessage = data.error?.message ?? "Falha ao chamar a API.";
+    throw new Error(errorMessage);
+  }
+
+  return data.choices?.[0]?.message?.content?.trim() ?? "Sem resposta da IA.";
+}
+
+askBtn.addEventListener("click", async () => {
+  const apiKey = apiKeyInput.value.trim();
+  const question = questionInput.value.trim();
+
+  if (!apiKey) {
+    answerEl.textContent = "Informe sua API key do OpenRouter.";
+    return;
+  }
+
+  if (!question) {
+    answerEl.textContent = "Digite uma pergunta antes de enviar.";
+    return;
+  }
+
+  askBtn.disabled = true;
+  askBtn.textContent = "Perguntando...";
+  answerEl.textContent = "Carregando resposta...";
+
+  try {
+    const result = await askAI(apiKey, question);
+    answerEl.textContent = result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado.";
+    answerEl.textContent = `Erro: ${message}`;
+  } finally {
+    askBtn.disabled = false;
+    askBtn.textContent = "Perguntar";
+  }
+});

--- a/app.ts
+++ b/app.ts
@@ -1,0 +1,91 @@
+type ChatMessage = {
+  role: "system" | "user";
+  content: string;
+};
+
+type OpenRouterResponse = {
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+};
+
+const apiKeyInput = document.querySelector<HTMLInputElement>("#apiKey");
+const questionInput = document.querySelector<HTMLTextAreaElement>("#question");
+const askBtn = document.querySelector<HTMLButtonElement>("#askBtn");
+const answerEl = document.querySelector<HTMLElement>("#answer");
+
+if (!apiKeyInput || !questionInput || !askBtn || !answerEl) {
+  throw new Error("Elementos do app não encontrados no DOM.");
+}
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const FREE_MODEL = "meta-llama/llama-3.3-8b-instruct:free";
+
+async function askAI(apiKey: string, question: string): Promise<string> {
+  const messages: ChatMessage[] = [
+    {
+      role: "system",
+      content: "Você é um assistente útil e responde em português do Brasil.",
+    },
+    { role: "user", content: question },
+  ];
+
+  const response = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "HTTP-Referer": window.location.origin,
+      "X-Title": "App IA Grátis Exemplo",
+    },
+    body: JSON.stringify({
+      model: FREE_MODEL,
+      messages,
+      temperature: 0.7,
+    }),
+  });
+
+  const data = (await response.json()) as OpenRouterResponse;
+
+  if (!response.ok) {
+    const errorMessage = data.error?.message ?? "Falha ao chamar a API.";
+    throw new Error(errorMessage);
+  }
+
+  return data.choices?.[0]?.message?.content?.trim() ?? "Sem resposta da IA.";
+}
+
+askBtn.addEventListener("click", async () => {
+  const apiKey = apiKeyInput.value.trim();
+  const question = questionInput.value.trim();
+
+  if (!apiKey) {
+    answerEl.textContent = "Informe sua API key do OpenRouter.";
+    return;
+  }
+
+  if (!question) {
+    answerEl.textContent = "Digite uma pergunta antes de enviar.";
+    return;
+  }
+
+  askBtn.disabled = true;
+  askBtn.textContent = "Perguntando...";
+  answerEl.textContent = "Carregando resposta...";
+
+  try {
+    const result = await askAI(apiKey, question);
+    answerEl.textContent = result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado.";
+    answerEl.textContent = `Erro: ${message}`;
+  } finally {
+    askBtn.disabled = false;
+    askBtn.textContent = "Perguntar";
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pergunte à IA (API grátis)</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Pergunte à IA</h1>
+      <p class="subtitle">Exemplo simples em HTML + CSS + TypeScript (com JavaScript pronto para rodar).</p>
+
+      <label for="apiKey">Chave da API (OpenRouter)</label>
+      <input id="apiKey" type="password" placeholder="sk-or-v1-..." />
+
+      <label for="question">Sua pergunta</label>
+      <textarea id="question" rows="5" placeholder="Digite sua pergunta..."></textarea>
+
+      <button id="askBtn">Perguntar</button>
+
+      <section class="result">
+        <h2>Resposta</h2>
+        <pre id="answer">A resposta aparecerá aqui.</pre>
+      </section>
+    </main>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,88 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --panel: #141b34;
+  --text: #e8ecff;
+  --muted: #98a4d7;
+  --accent: #6c7dff;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #182146, var(--bg));
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.container {
+  width: min(760px, 100%);
+  background: var(--panel);
+  border: 1px solid #2a356b;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 12px 40px rgb(0 0 0 / 25%);
+}
+
+h1 {
+  margin-top: 0;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  margin: 8px 0;
+}
+
+input,
+textarea,
+button {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #35437d;
+  padding: 12px;
+  font-size: 1rem;
+}
+
+input,
+textarea {
+  color: var(--text);
+  background: #10162e;
+}
+
+button {
+  margin-top: 12px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.result {
+  margin-top: 20px;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #0f1530;
+  border: 1px solid #2a356b;
+  border-radius: 10px;
+  padding: 14px;
+  min-height: 110px;
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, self-contained web example that lets a user send a question to a free AI model via OpenRouter and display the response in the browser.
- Offer both a typed `app.ts` implementation and a ready-to-run `app.js` fallback so the example works without build tooling.

### Description
- Add `index.html` with inputs for the OpenRouter API key, a question textarea, an ask button, and a result area. 
- Add `styles.css` implementing a simple dark-themed, centered layout for inputs, button, and response panel. 
- Add `app.ts` implementing typed request/response shapes, validation, loading state, error handling, and a `fetch` call to `https://openrouter.ai/api/v1/chat/completions` using the free model `meta-llama/llama-3.3-8b-instruct:free`.
- Add `app.js` as an uncompiled JavaScript equivalent so the app can run directly in the browser without a TypeScript build step.

### Testing
- Ran `node --check app.js` to verify the generated JavaScript has no syntax errors, which succeeded. 
- An initial `tsc` run without library flags reported missing `Promise`/lib errors, so the TypeScript check was re-run as `tsc --noEmit --lib DOM,ES2015 app.ts` and that type-check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc352047988326a1ad790c1d8f18e3)